### PR TITLE
remove enum34 to avoid issue with python 3.5+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,3 @@ python-coveralls>=2.9.0
 pytest>=3.8.0
 pytest-cov==2.5.0
 six>=1.10.0
-enum34>=1.1.5
-


### PR DESCRIPTION
We experienced an issue in a python 3.6 environment during the install of dependencies due to enum34.

`AttributeError: module 'enum' has no attribute 'IntFlag'`

Generally, it's considered good practice to utilize enum34 with Python versions 3.4 (or earlier), as stated by the packages description[1] (and a number of additional GitHub issues[2][3]):

'Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4'

If you require the functionality of enum34, I'd recommend utilizing aenum[4], or another package which would fit your purposes. 

References:
[1] https://pypi.org/project/enum34/
[2] https://github.com/PyCQA/flake8-import-order/issues/148
[3] https://github.com/snipsco/snips-nlu/issues/649
[4] https://pypi.org/project/aenum/ 