### PR TITLE
401K_Support

### DIFF
--- a/intuitlib/client.py
+++ b/intuitlib/client.py
@@ -69,6 +69,18 @@ class AuthClient(requests.Session):
         self.x_refresh_token_expires_in = None
         self.id_token = id_token
         
+    def setAuthorizeURLs(self, urlObject):
+        """Set authorization url using custom values passed in the data dict
+        :param **data: data dict for custom authorizationURLS
+        :return: self
+        """
+        if urlObject is not None:
+            self.auth_endpoint = urlObject['auth_endpoint']
+            self.token_endpoint = urlObject['token_endpoint']
+            self.revoke_endpoint = urlObject['revoke_endpoint']
+            self.user_info_url = urlObject['user_info_url']
+        return None
+        
     def get_authorization_url(self, scopes, state_token=None):
         """Generates authorization url using scopes specified where user is redirected to
         

--- a/intuitlib/enums.py
+++ b/intuitlib/enums.py
@@ -33,6 +33,7 @@ class Scopes(Enum):
     PAYROLL = 'com.intuit.quickbooks.payroll'
     PAYROLL_TIMETRACKING = 'com.intuit.quickbooks.payroll.timetracking'
     PAYROLL_BENEFITS = 'com.intuit.quickbooks.payroll.benefits'
+    PAYSLIP_READ = 'com.intuit.quickbooks.payroll.payslip.read'
 
     # For migrated apps only
     # To not see consent page they should pass the following scopes - openid intuit_name email

--- a/intuitlib/utils.py
+++ b/intuitlib/utils.py
@@ -34,21 +34,22 @@ from intuitlib.config import DISCOVERY_URL, ACCEPT_HEADER
 
 def get_discovery_doc(environment, session=None):
     """Gets discovery doc based on environment specified.
-    
     :param environment: App environment, accepted values: 'sandbox','production','prod','e2e'
     :param session: `requests.Session` object if a session is already being used, defaults to None
     :return: Discovery doc response 
     :raises HTTPError: if response status != 200
     """
-
     if environment.lower() in ['production', 'prod']:
         discovery_url = DISCOVERY_URL['production']
-    else:
+    elif environment.lower() in ['sandbox', 'sand']:
         discovery_url = DISCOVERY_URL['sandbox']
-    
-
-    response = requests.get(url=discovery_url, headers={'User-Agent': 'Mozilla/5.0'})
+    else:
+        discovery_url = environment
         
+    if session is not None and isinstance(session, Session):
+        response = session.get(url=discovery_url)
+    else:
+        response = requests.get(url=discovery_url)
     if response.status_code != 200:
         raise AuthClientError(response)
     return response.json()

--- a/intuitlib/version.py
+++ b/intuitlib/version.py
@@ -12,4 +12,4 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ future>=0.16.0
 requests>=2.13.0
 mock>=2.0.0
 requests_oauthlib>=1.0.0
-coverage==4.0.3
+coverage==4.4
 python-coveralls>=2.9.0
 pytest>=3.8.0
 pytest-cov==2.5.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,8 +52,8 @@ class TestUtils():
         assert discovery_doc['issuer'] == 'https://oauth.platform.intuit.com/op/v1'
         assert discovery_doc['userinfo_endpoint'] == 'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
 
-    def test_get_discovery_doc_invalid_input(self):
-        discovery_doc = get_discovery_doc('random')
+    def test_get_discovery_doc_custom_url_input(self):
+        discovery_doc = get_discovery_doc('https://developer.intuit.com/.well-known/openid_sandbox_configuration/')
         
         assert discovery_doc['issuer'] =='https://oauth.platform.intuit.com/op/v1'
         assert discovery_doc['userinfo_endpoint'] == 'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'


### PR DESCRIPTION
Adding support for 401k use case. Changes added : 

1.) `setAuthorizeURLs` helper function to pass custom auth URL's
2.) Payslip Enum added
3.) Utils modification to handle any custom discovery doc URL's passed as plain string
4.) version change to `1.2.4`