### PR TITLE
Remove future dependency

### DIFF
--- a/intuitlib/client.py
+++ b/intuitlib/client.py
@@ -15,8 +15,12 @@
 from __future__ import absolute_import
 
 import json
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
 import requests
-from future.moves.urllib.parse import urlencode
 
 from intuitlib.utils import (
     get_discovery_doc,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 python_jose>=2.0.2
-future>=0.16.0
 requests>=2.13.0
 mock>=2.0.0
 requests_oauthlib>=1.0.0
@@ -9,5 +8,3 @@ pytest>=3.8.0
 pytest-cov==2.5.0
 six>=1.10.0
 enum-compat
-
-

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     namespace_packages=('intuitlib',),
     install_requires=[
         'python_jose>=2.0.2',
-        'future>=0.16.0',
         'requests>=2.13.0',
         'requests_oauthlib>=1.0.0',
         'six>=1.10.0',


### PR DESCRIPTION
Using a thirdparty dependency as big as `future` for just `urlencode()` does not seem worth it