### PR TITLE
Remove the enum-compat dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'requests>=2.13.0',
         'requests_oauthlib>=1.0.0',
         'six>=1.10.0',
-        'enum-compat',
+        'enum34; python_version < "3.4"',
     ],
     license='Apache 2.0',
     keywords='intuit quickbooks oauth auth openid client'


### PR DESCRIPTION
This patch removes the `enum-compat` dependency and replaces it with a
conditional dependency on `enum34`. This is all the `enum-compat`
package does.
