### PR TITLE
Support pickling AuthClientError

### DIFF
--- a/intuitlib/exceptions.py
+++ b/intuitlib/exceptions.py
@@ -12,7 +12,6 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 
-import requests
 
 class AuthClientError(Exception):
     """AuthClient Error object in case API response status != 200
@@ -33,3 +32,6 @@ class AuthClientError(Exception):
         self.timestamp = response.headers.get('Date', None) 
 
         Exception.__init__(self, 'HTTP status {0}, error message: {1}, intuit_tid {2} at time {3}'.format(self.status_code, self.content, self.intuit_tid, self.timestamp)) 
+
+    def __reduce__(self):
+        return self.__class__, (self.response,)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,13 @@
+import pickle
+
+from intuitlib.exceptions import AuthClientError
+from tests.helper import MockResponse
+
+
+class TestExceptions:
+    def mock_request(self, status=200, content=None):
+        return MockResponse(status=status, content=content)
+
+    def test_authclienterror_is_pickleable(self):
+        error = AuthClientError(self.mock_request(404))
+        pickle.dumps(error)


### PR DESCRIPTION
This PR supports `AuthClientError` pickleable. This is useful in distributed or multiprocessing environments such as Celery.