### PR TITLE
Don't persist headers across requests

### DIFF
--- a/intuitlib/utils.py
+++ b/intuitlib/utils.py
@@ -85,7 +85,7 @@ def send_request(method, url, header, obj, body=None, session=None, oauth1_heade
     :return: requests object
     """
 
-    headers = ACCEPT_HEADER
+    headers = ACCEPT_HEADER.copy()
     header.update(headers)
 
     if session is not None and isinstance(session, Session):


### PR DESCRIPTION
Don't persist headers across requests.

If you send a POST request followed by a GET request, then headers provided by the POST request such as e.g. 'Content-Type': 'application/x-www-form-urlencoded' will be sent also with the GET request, where they are unexpected and will cause 415 errors from QuickBooks Online API.
