### PR TITLE
Remove import from future library to prevent error with python 3.12

### DIFF
--- a/intuitlib/client.py
+++ b/intuitlib/client.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 import json
 import requests
-from future.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from intuitlib.utils import (
     get_discovery_doc,


### PR DESCRIPTION
Remove import from future library to prevent error with python 3.12