### PR TITLE
remove uninstalled imports of future and enforce python3

### DIFF
--- a/intuitlib/client.py
+++ b/intuitlib/client.py
@@ -13,12 +13,9 @@
  # limitations under the License.
 
 import json
-import requests
+from urllib.parse import urlencode
 
-try:
-  from urllib.parse import urlencode
-except (ModuleNotFoundError, ImportError):
-  from future.moves.urllib.parse import urlencode
+import requests
 
 from intuitlib.utils import (
     get_discovery_doc,

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'six>=1.10.0',
         'enum-compat',
     ],
+    python_requires='>=3',
     license='Apache 2.0',
     keywords='intuit quickbooks oauth auth openid client'
 )


### PR DESCRIPTION
Cleanup changes following #45

* Remove all mentions of `future` now that it is no longer a dependency
* Enforce Python 3 now that `future` is no longer installed