### PR TITLE
Use OIC instead of Python-Jose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python_jose>=2.0.2
 requests>=2.13.0
 mock>=2.0.0
 requests_oauthlib>=1.0.0
@@ -8,3 +7,4 @@ pytest>=3.8.0
 pytest-cov==2.5.0
 six>=1.10.0
 enum-compat
+oic==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pytest>=3.8.0
 pytest-cov==2.5.0
 six>=1.10.0
 enum-compat
-oic==1.7.0
+oic

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'requests_oauthlib>=1.0.0',
         'six>=1.10.0',
         'enum-compat',
-        'oic==1.7.0',
+        'oic',
     ],
     license='Apache 2.0',
     keywords='intuit quickbooks oauth auth openid client'

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,11 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     namespace_packages=('intuitlib',),
     install_requires=[
-        'python_jose>=2.0.2',
         'requests>=2.13.0',
         'requests_oauthlib>=1.0.0',
         'six>=1.10.0',
         'enum-compat',
+        'oic==1.7.0',
     ],
     license='Apache 2.0',
     keywords='intuit quickbooks oauth auth openid client'


### PR DESCRIPTION
## Context

This package indirectly uses python-jose, which is affected by: https://github.com/advisories/GHSA-cjwg-qfpm-7377 which additionally seems to be [abandoned](https://github.com/mpdavis/python-jose/pull/352#issuecomment-2100580833) by it's maintainers. 

Move this package to use [OIC](https://github.com/CZ-NIC/pyoidc) to generate the JWK instead. 