### PR TITLE
Use PyJWT instead of python-jose

### DIFF
--- a/intuitlib/utils.py
+++ b/intuitlib/utils.py
@@ -164,7 +164,7 @@ def validate_id_token(id_token, client_id, intuit_issuer, jwk_uri):
         return False
 
     message = id_token_parts[0] + '.' + id_token_parts[1]
-    public_key = get_jwk(id_token_header['kid'], jwk_uri)
+    public_key = get_jwk(id_token_header['kid'], jwk_uri).key
 
     is_signature_valid = public_key.verify(message.encode('utf-8'), id_token_signature)
     return is_signature_valid

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pytest>=3.8.0
 pytest-cov==2.5.0
 six>=1.10.0
 enum-compat
-pyjwt>=2.0.0
+pyjwt[crypto]>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python_jose>=2.0.2
 requests>=2.13.0
 mock>=2.0.0
 requests_oauthlib>=1.0.0
@@ -8,3 +7,4 @@ pytest>=3.8.0
 pytest-cov==2.5.0
 six>=1.10.0
 enum-compat
+pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pytest>=3.8.0
 pytest-cov==2.5.0
 six>=1.10.0
 enum-compat
-pyjwt
+pyjwt>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     namespace_packages=('intuitlib',),
     install_requires=[
-        'python_jose>=2.0.2',
+        'pyjwt',
         'requests>=2.13.0',
         'requests_oauthlib>=1.0.0',
         'six>=1.10.0',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     namespace_packages=('intuitlib',),
     install_requires=[
-        'pyjwt',
+        'pyjwt>=2.0.0',
         'requests>=2.13.0',
         'requests_oauthlib>=1.0.0',
         'six>=1.10.0',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     namespace_packages=('intuitlib',),
     install_requires=[
-        'pyjwt>=2.0.0',
+        'pyjwt[crypto]>=2.0.0',
         'requests>=2.13.0',
         'requests_oauthlib>=1.0.0',
         'six>=1.10.0',


### PR DESCRIPTION
Alternate to https://github.com/intuit/oauth-pythonclient/pull/48/

## Context
 
This package indirectly uses python-jose, which is affected by: [GHSA-cjwg-qfpm-7377](https://github.com/advisories/GHSA-cjwg-qfpm-7377) which additionally seems to be [abandoned](https://github.com/mpdavis/python-jose/pull/352#issuecomment-2100580833) by it's maintainers.

Move this package to use [PyJWT](https://github.com/jpadilla/pyjwt/) to generate the JWK instead.

